### PR TITLE
Add UltiSnips snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-## Installation
+Hspec.vim
+---------
+
+Vim plugin providing support for the [Hspec] BDD-style testing framework for
+Haskell.
+
+### Installation
 
 If you are using [pathogen.vim](https://github.com/tpope/vim-pathogen), then
 you can install `hspec.vim` with:
@@ -7,6 +13,8 @@ you can install `hspec.vim` with:
 cd ~/.vim/bundle
 git clone https://github.com/hspec/hspec.vim
 ```
+
+### Syntax
 
 By default spec files are highlighted the same as ordinary Haskell source
 files.  You can customize colors by adding e.g. the following to your `.vimrc`:
@@ -18,3 +26,17 @@ highlight link hspecDescription Comment
 ```
 
 ![screenshot of vim with hspec.vim](https://raw.github.com/hspec/hspec.vim/master/screenshot.png "hspec.vim awesomeness in pictures")
+
+### Snippets
+
+The plugin includes [UltiSnips] snippets for the Hspec DSL. If you have
+UltiSnips installed, no configuration is necessary, simply edit a file matching
+`*Spec.hs`.
+
+Press `Ctrl-Tab` in insert mode to list all available snippets in context, where
+descriptions will indicate the Hspec snippets. Or just try a few of the most
+common triggers: `spec`, `des`, `con`, `it`, etc.
+
+[Hspec]: http://hspec.github.io/
+[UltiSnips]: https://github.com/SirVer/ultisnips
+

--- a/UltiSnips/hspec.snippets
+++ b/UltiSnips/hspec.snippets
@@ -1,0 +1,147 @@
+#-------------------------------------------------------------------------------
+# UltiSnips snippets for Hspec - http://hspec.github.io/
+#
+# Many triggers modeled on RSpec triggers.
+#-------------------------------------------------------------------------------
+
+priority -50
+
+extends haskell
+
+# See: http://hspec.github.io/hspec-discover.html
+snippet hdisc "Hspec: discovery magic preproc comment" b
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+endsnippet
+
+
+# This can be used as a standalone main suite, or a single file when using
+# discovery. The main method then allows it to be individually tested from GHCi.
+snippet spec "Hspec: new suite" b
+module ${1:Subject.MySpec} (main, spec) where
+
+import Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+	describe "${2:subject}" $ do
+		$0
+endsnippet
+
+
+snippet hspec "Hspec: begin suite"
+hspec $ do
+	des$0
+endsnippet
+
+
+snippet bef "Hspec: suite with before hook"
+hspec $ before ${1:ioAction} $ do
+	des$0
+endsnippet
+
+
+snippet aft "Hspec: suite with after hook"
+hspec $ after ${1:ioAction} $ do
+	des$0
+endsnippet
+
+
+snippet around "Hspec: suite with around hook"
+hspec $ around ${1:ioWrapper} $ do
+	des$0
+endsnippet
+
+
+snippet pw "Hspec: pendingWith" b
+pendingWith "${1:explanation}"
+endsnippet
+
+
+snippet des "Hspec: describe block" b
+describe "${1:subject}" $ do
+	$0
+endsnippet
+
+
+snippet con "Hspec: context block" b
+context "${1:context}" $ do
+	$0
+endsnippet
+
+
+snippet it "Hspec: it block" b
+it "${1:does something}" $ do
+	$0
+endsnippet
+
+
+# Prefer active voice, but for some this is an ingrained habit.
+snippet its "Hspec: it should" b
+it "should ${1:do something}" $ do
+	$0
+endsnippet
+
+
+snippet itr "Hspec: it with resource loaner pattern" b
+it "${1:does something}" $ ${2:withResource} $ \\${3:rs} -> do
+	$0
+endsnippet
+
+#-------------------------------------------------------------------------------
+# Expectations
+#
+# TODO: has this behavior broken in UltiSnips? Doesn't seem to work for me anymore
+#   http://fueledbylemons.com/blog/2011/07/27/why-ultisnips/#different-beginning-of-line-snippet
+#-------------------------------------------------------------------------------
+
+snippet shb "Hspec: shouldBe"
+\`shouldBe\` ${1:result}
+endsnippet
+
+
+snippet shb "Hspec: shouldBe" !b
+${1:subject} \`shouldBe\` ${2:result}
+endsnippet
+
+
+snippet shret "Hspec: shouldReturn"
+\`shouldReturn\` ${1:result}
+endsnippet
+
+
+snippet shret "Hspec: shouldReturn" !b
+${1:subject} \`shouldReturn\` ${2:result}
+endsnippet
+
+
+snippet shs "Hspec: shouldSatisfy"
+\`shouldSatisfy\` ${1:(${2:not . null})}
+endsnippet
+
+
+snippet shs "Hspec: shouldSatisfy" !b
+${1:subject} \`shouldSatisfy\` ${2:(${3:not . null})}
+endsnippet
+
+
+snippet sht "Hspec: shouldThrow"
+\`shouldThrow\` ${1:anyException}
+endsnippet
+
+
+snippet sht "Hspec: shouldThrow" !b
+${1:evaluate (${2:subject})} \`shouldThrow\` ${3:anyException}
+endsnippet
+
+#-------------------------------------------------------------------------------
+# Hspec with QuickCheck
+#-------------------------------------------------------------------------------
+
+snippet itp "Hspec: it with QuickCheck property" b
+it "${1:does something}" $ property $
+	\\${3:subj} -> $0
+endsnippet
+

--- a/ftdetect/hspec.vim
+++ b/ftdetect/hspec.vim
@@ -1,1 +1,1 @@
-autocmd BufReadPost,BufNewFile *Spec.hs set filetype=hspec
+autocmd BufReadPost,BufNewFile *Spec.hs set filetype=haskell.hspec


### PR DESCRIPTION
[UltiSnips](https://github.com/SirVer/ultisnips) is a spiffy snippets plugin. I wrote these snippets for myself, and when I noticed hspec.vim I thought they would make a worthy contribution.

UltiSnips scans directories in `runtimepath` for a child directory called `UltiSnips` and registers snippets from each one that it finds, so it's easy for plugins to maintain and bundle their own. Snippets are loaded based on filetype and Vim's dotted syntax is supported for multiple sources. So altogether, it's quite nonintrusive since if you don't use UltiSnips, nothing superfluous is loaded, and if you do, Hspec snippets will just work.
