### PR TITLE
Auto-detection fix

### DIFF
--- a/syntax/hspec.vim
+++ b/syntax/hspec.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Simon Hengel <sol@typeful.net>
 " Last Change:  2013 May 18
 
-if exists("b:current_syntax")
+if exists("b:current_syntax") && b:current_syntax == "hspec"
   finish
 endif
 


### PR DESCRIPTION
Check my math, but this fix seems to work with `*Spec.hs`, `*.hs`, other syntax-matched files and new buffers.

Without this patch, `*Spec.hs` are always matched as `ft=haskell`
