### PR TITLE
Add HspecOpenTest command and default mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Haskell.
 
 ### Installation
 
+Compatible with *Vundle*, *Pathogen*, *Vim-plug*.
+
 If you are using [pathogen.vim](https://github.com/tpope/vim-pathogen), then
 you can install `hspec.vim` with:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Haskell.
 
 ### Installation
 
-Compatible with *Vundle*, *Pathogen*, *Vim-plug*.
+Compatible with *Vundle*, *Pathogen*, *Vim-plug*, etc.
 
 If you are using [pathogen.vim](https://github.com/tpope/vim-pathogen), then
 you can install `hspec.vim` with:
@@ -29,6 +29,15 @@ highlight link hspecDescription Comment
 
 ![screenshot of vim with hspec.vim](https://raw.github.com/hspec/hspec.vim/master/screenshot.png "hspec.vim awesomeness in pictures")
 
+### Commands
+
+The plugin includes the `HspecOpenTest` command, that allows you to open the
+Spec test for the current source file. It also provides a default mapping `ghs`
+(Go Hspec).
+
+By default `HspecOpenTest` will recursively find your tests in `test/` and
+`../test`.
+
 ### Snippets
 
 The plugin includes [UltiSnips] snippets for the Hspec DSL. If you have
@@ -41,6 +50,32 @@ common triggers: `spec`, `des`, `con`, `it`, etc.
 
 [Hspec]: http://hspec.github.io/
 [UltiSnips]: https://github.com/SirVer/ultisnips
+
+### Configuration
+
+Remove the default mapping with (default = `0`):
+
+```vims
+let g:hspec_disable_maps = 1
+```
+
+Add directories where your tests reside (default = `['test', '../test']`):
+
+```vim
+let g:hspec_tests_dir = ['test', '../test', 'some_dir']
+```
+
+Change the test files prefix (default = `''`):
+
+```vim
+let g:hspec_tests_prefix = 'prefix'
+```
+
+Change the test files suffix (default = `'Spec'`):
+
+```vim
+let g:hspec_tests_suffix = 'Spec'
+```
 
 ### License
 

--- a/autoload/hspec.vim
+++ b/autoload/hspec.vim
@@ -1,5 +1,5 @@
 if !exists("g:hspec_tests_dir")
-    let g:hspec_tests_dir = ['test']
+    let g:hspec_tests_dir = ['test', '../test']
 endif
 
 if !exists("g:hspec_tests_prefix")
@@ -14,10 +14,13 @@ function! hspec#OpenTest()
     let l:current_filename = expand("%:t:r")
     let l:test_filename = g:hspec_tests_prefix . l:current_filename . g:hspec_tests_suffix . ".hs"
 
-    let l:test_file = findfile(l:test_filename, g:hspec_tests_dir[0] . "/**/")
-    if l:test_file !=? ""
-        exe ":e " . l:test_file
-    else
-        echom "Test file \"" . l:test_filename . "\" does not exist!"
-    endif
+    for dir in g:hspec_tests_dir
+        let l:test_file = findfile(l:test_filename, dir . "/**/")
+        if l:test_file !=? ""
+            exe ":e " . l:test_file
+            return
+        endif
+    endfor
+
+    echom "Test file \"" . l:test_filename . "\" does not exist!"
 endfunction

--- a/autoload/hspec.vim
+++ b/autoload/hspec.vim
@@ -1,0 +1,23 @@
+if !exists("g:hspec_tests_dir")
+    let g:hspec_tests_dir = ['test']
+endif
+
+if !exists("g:hspec_tests_prefix")
+    let g:hspec_tests_prefix = ''
+endif
+
+if !exists("g:hspec_tests_suffix")
+    let g:hspec_tests_suffix = 'Spec'
+endif
+
+function! hspec#OpenTest()
+    let l:current_filename = expand("%:t:r")
+    let l:test_filename = g:hspec_tests_prefix . l:current_filename . g:hspec_tests_suffix . ".hs"
+
+    let l:test_file = findfile(l:test_filename, g:hspec_tests_dir[0] . "/**/")
+    if l:test_file !=? ""
+        exe ":e " . l:test_file
+    else
+        echom "Test file \"" . l:test_filename . "\" does not exist!"
+    endif
+endfunction

--- a/plugin/hspec.vim
+++ b/plugin/hspec.vim
@@ -5,5 +5,5 @@ if !exists("g:hspec_disable_maps")
 endif
 
 if exists("g:hspec_disable_maps") && g:hspec_disable_maps == 0
-    nnoremap gH :HspecOpenTest<CR>
+    nnoremap ghs :HspecOpenTest<CR>
 endif

--- a/plugin/hspec.vim
+++ b/plugin/hspec.vim
@@ -1,0 +1,9 @@
+command! HspecOpenTest call hspec#OpenTest()
+
+if !exists("g:hspec_disable_maps")
+    let g:hspec_disable_maps = 0
+endif
+
+if exists("g:hspec_disable_maps") && g:hspec_disable_maps == 0
+    nnoremap gH :HspecOpenTest<CR>
+endif

--- a/plugin/hspec.vim
+++ b/plugin/hspec.vim
@@ -5,5 +5,8 @@ if !exists("g:hspec_disable_maps")
 endif
 
 if exists("g:hspec_disable_maps") && g:hspec_disable_maps == 0
-    nnoremap ghs :HspecOpenTest<CR>
+    augroup hspec
+        au!
+        au FileType haskell nnoremap ghs :HspecOpenTest<CR>
+    augroup END
 endif


### PR DESCRIPTION
So here is a little convenience: When working in a file `Foo.hs` now is possible to do **ghs** (the default mapping) to jump to `FooSpec.hs`.

This defines a command `HspecOpenTest` and a default mapping for it `ghs`.

It allows some configuration as well:

* Disable the default mapping (`ghs`)
* Add directories where to look for the tests (recursively)
* Test files prefix
* Test files suffix (default is `Spec`)